### PR TITLE
fix(middleware/caching): correct waitUntil binding

### DIFF
--- a/src/middleware/caching.js
+++ b/src/middleware/caching.js
@@ -51,8 +51,8 @@ export function createCacheRouter({ cacheName, match: matcher, fetchOptions } = 
           cachedResponse =>
             cachedResponse ||
             fetchAndCache({
+              waitUntil: promise => event.waitUntil(promise),
               request: event.request,
-              waitUntil: event.waitUntil,
               cacheName: name,
               fetchOptions,
             }),


### PR DESCRIPTION
Fix for illegal invocation caused by using `event.waitUntil` being ambiguously bound.