### PR TITLE
chore(workflows): added Github Action for stale issue/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,11 +13,10 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove no-issue-activity label or comment or this will be closed in 5 days.'
-        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove no-pr-activity label or comment or this will be closed in 5 days.'
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
+        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
         stale-issue-label: 'no-issue-activity'
         exempt-issue-label: 'no-issue-activity'
         exempt-pr-label: 'no-pr-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 30
-        days-before-close: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,8 @@ jobs:
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove no-issue-activity label or comment or this will be closed in 5 days.'
         stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove no-pr-activity label or comment or this will be closed in 5 days.'
         stale-issue-label: 'no-issue-activity'
-        exempt-issue-label: 'enhancement'
+        exempt-issue-label: 'no-issue-activity'
+        exempt-pr-label: 'no-pr-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
This PR is to update GitHub action for stale issues/PRs so they are only labeled as stale but not auto-closed.