### PR TITLE
fix(release): target release-staging

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,16 +1,14 @@
-name: Release
+name: Release Staging
 
 on:
-  pull_request:
+  push:
     branches:
       - master
-    types:
-      - closed
 
 jobs:
   release_package:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged && github.head_ref == 'release-staging'
+    if: github.head_ref != 'release-staging'
 
     steps:
     - uses: actions/checkout@v2
@@ -29,9 +27,11 @@ jobs:
       env:
         NODE_ENV: development
       run: yarn
-    - name: NPM publishing
+    - name: Semantic release
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: |
-        sed -i. 's/"private": true/"private": false/' package.json
-        npm publish --access public
+        GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+        GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+        GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+        GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -114,10 +114,9 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
-      "@semantic-release/git",
-      "@semantic-release/npm"
+      "@semantic-release/git"
     ],
-    "branch": "master"
+    "branch": "release-staging"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Being that master branch is protected, the release strategy has been modified to prepare release stages on `release-staging` branch with every pull request merged into master. When we are ready to release, we open a PR from `release-staging` to `master` and will publish the changes.