### PR TITLE
chore(release): not persist github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@americanexpress/one-service-worker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A service worker built for the modern web",
   "license": "Apache-2.0",
   "homepage": "https://github.com/americanexpress/one-service-worker",


### PR DESCRIPTION
https://github.com/semantic-release/git/issues/196#issuecomment-601310576

This would allow the env variables to not persist and be used during semantic release. This is a workaround as the issue is still open 